### PR TITLE
画像の複数枚投稿機能の実装

### DIFF
--- a/app/assets/javascripts/items/new.js
+++ b/app/assets/javascripts/items/new.js
@@ -1,0 +1,29 @@
+$(document).on('turbolinks:load', ()=> {
+  // 画像用のinputを生成する関数
+  const buildFileField = (index)=> {
+    const html = `<div data-index="${index}" class="js-file_group">
+                    <input class="js-file" type="file"
+                    name="product[images_attributes][${index}][src]"
+                    id="product_images_attributes_${index}_src"><br>
+                    <div class="js-remove">削除</div>
+                  </div>`;
+    return html;
+  }
+
+  // file_fieldのnameに動的なindexをつけるための配列
+  let fileIndex = [1,2,3,4,5,6,7,8,9,10];
+
+  $('#image-box').on('change', '.js-file', function(e){
+    // fileIndexの先頭の数字を使ってinputを作る
+    $('#image-box').append(buildFileField(fileIndex[0]));
+    fileIndex.shift();
+    // 末尾の数に1足した数を追加する
+    fileIndex.push(fileIndex[fileIndex.length - 1] + 1)
+  });
+
+  $('#image-box').on('click', '.js-remove', function(){
+    $(this).parent().remove();
+    // 画像入力欄が0個にならないようにしておく
+    if ($('.js-file').length == 0) $('#image-box').append(buildFileField(fileIndex[0]));
+  });
+});

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -10,7 +10,9 @@
         .description 最大10枚までアップロードできます
         #image-box.image-form
           = f.fields_for :item_images do |i|
-            = i.file_field :image
+            .js-file_group{data: {index: {id: i.index}}}
+              = i.file_field :image, class: 'js-file'
+              .js-remove 削除
       .container__main-content__item
         %ul
           %li  


### PR DESCRIPTION
# What
jsを用いて画像が複数枚投稿できるように実装を行なった。

# Why
商品出品機能では画像が10枚まで投稿できるようにする必要があるため。