### PR TITLE
商品一覧表示

### DIFF
--- a/app/assets/stylesheets/items/_index.scss
+++ b/app/assets/stylesheets/items/_index.scss
@@ -250,9 +250,9 @@
         .out {
           display: inline-block;
           position: absolute;
-          top: 50px;
-          left: 55px;
-          border-radius: 15%;
+          top: 48px;
+          left: 50px;
+          border-radius: 13%;
           font-size: 1.8rem;
           text-align: center;
           font-weight: bold;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,8 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.includes(:user).order("created_at DESC").limit(5)
     @parents = Category.where(ancestry: nil)
+    @newitems = Item.includes(:item_images).order("created_at DESC").limit(5)
+    @branditems = Item.includes(:item_images).order("brand DESC").limit(5)
   end
 
   def new

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -89,27 +89,41 @@
   .subtitle
     = link_to "新規投稿商品", root_path
   .products
-    - @items.each do |item|
+    - @newitems.each do |item|
       = link_to item_path(item.id) do
-        .products__box__image
-          - if item.buyer_id
-            = image_tag ("icon-04.png")
+        - if item.buyer_id.present?
+          .products__box__image
+            = image_tag item.item_images[0].image.url
             %spen.out SOLD
-          - else
-            = image_tag ("icon-01.png")
-        .products__box__body
-          %h3.name
-            = item.name
-          %ul.details
-            %li.details__price
-              = item.price.to_s
-              %spen.unit円
-            %li.details__icon
-              = icon("fas", "star")
-            %li.details__count
-              0
-          .tax
-            = "（税込）"
+          .products__box__body
+            %h3.name
+              = item.name
+            %ul.details
+              %li.details__price
+                = item.price.to_s
+                %spen.unit円
+              %li.details__icon
+                = icon("fas", "star")
+              %li.details__count
+                0
+            .tax
+              = "（税込）"
+        - else
+          .products__box__image
+            = image_tag item.item_images[0].image.url
+          .products__box__body
+            %h3.name
+              = item.name
+            %ul.details
+              %li.details__price
+                = item.price.to_s
+                %spen.unit円
+              %li.details__icon
+                = icon("fas", "star")
+              %li.details__count
+                0
+            .tax
+              = "（税込）"
 
 %section.pickup
   %h2.title
@@ -117,27 +131,42 @@
   .subtitle
     = link_to "アーカイバ", root_path
   .products
-    - @items.each do |item|
+    - @branditems.each do |item|
       = link_to item_path(item.id) do
-        .products__box__image
-          - if item.brand and item.buyer_id
-            = image_tag ("icon-04.png")
+        - if item.buyer_id.present? && item.brand.present?
+          .products__box__image
+            = image_tag item.item_images[0].image.url
             %spen.out SOLD
-          - else item.brand
-            = image_tag ("icon-01.png")
-        .products__box__body
-          %h3.name
-            = item.name
-          %ul.details
-            %li.details__price
-              = item.price.to_s
-              %spen.unit円
-            %li.details__icon
-              = icon("fas", "star")
-            %li.details__count
-              0
-          .tax
-            = "（税込）"
+          .products__box__body
+            %h3.name
+              = item.name
+            %ul.details
+              %li.details__price
+                = item.price.to_s
+                %spen.unit円
+              %li.details__icon
+                = icon("fas", "star")
+              %li.details__count
+                0
+            .tax
+              = "（税込）"
+        - elsif item.brand.present?
+          .products__box__image
+            = image_tag item.item_images[0].image.url
+          .products__box__body
+            %h3.name
+              = item.name
+            %ul.details
+              %li.details__price
+                = item.price.to_s
+                %spen.unit円
+              %li.details__icon
+                = icon("fas", "star")
+              %li.details__count
+                0
+            .tax
+              = "（税込）"
+
 
 %section.bottom-image
   .contents


### PR DESCRIPTION
#WHAT
タルロに記載されている内容より抜粋
・ログアウト状態でも商品一覧ページを見ることができる
・見本と同じような形で、データベースに保存されている情報が確認できるようになっている
・画像素材が表示されている。画像がリンク切れなどになっていない
・売り切れた商品は表示されない、または売り切れたことがわかるようになっている
・出品した商品の一覧表示ができている。かつ「画像/価格/商品名」の3つの情報について表示できている
#WHY
トップページで新商品情報及びブランド情報を表示してユーザビリティを向上させるため