### PR TITLE
新規ユーザー登録・ログイン画面のマークアップ

### DIFF
--- a/app/assets/stylesheets/users/_devise.scss
+++ b/app/assets/stylesheets/users/_devise.scss
@@ -65,7 +65,7 @@
   margin: 30px;
 }
 
-.submit__btn{
+.submit__btn__user{
   display: block;
   background-color: #3CCABE;
   color: white;

--- a/app/assets/stylesheets/users/_devise.scss
+++ b/app/assets/stylesheets/users/_devise.scss
@@ -74,12 +74,23 @@
   border-radius: 10px;
   height: 35px;
   margin: 0 auto;
+  &:hover{
+    background-color: #70d3cb;
+  }
 }
 .link__btn{
   &__center{
   display: flex;
   justify-content: center;
   text-decoration: none;
-  margin: 10px;
+  margin-top: 15px;
+  font-size: 14px;
   }
 }
+// 誕生日欄で使用
+.year,.month,.day{
+  width: 80px;
+  height: 35px;
+}
+
+

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,6 +12,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # POST /resource
   def create
+    params[:user][:birthday] = birthday_join
     @user = User.new(sign_up_params)
     unless @user.valid?
       flash.now[:alert] = @user.errors.full_messages
@@ -67,6 +68,20 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def address_params
     params.require(:address).permit(:receiving_family_name, :receiving_first_name, :receiving_family_name_reading, :receiving_first_name_reading, 
       :post_code, :prefecture_id, :municipality, :street_number, :apartment_name, :telephone_number)
+  end
+
+
+  def birthday_join
+    # パラメータ取得
+    date = params[:birthday]
+
+    # ブランク時のエラー回避のため、どの値一つでもブランクだったら何もしない
+    if date["birthday(1i)"].empty? || date["birthday(2i)"].empty? || date["birthday(3i)"].empty?
+      return
+    end
+
+    # 年月日別々のものを結合して新しいDate型変数を作って返す
+    Date.new date["birthday(1i)"].to_i,date["birthday(2i)"].to_i,date["birthday(3i)"].to_i
   end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params

--- a/app/views/devise/passwords/new.html.haml
+++ b/app/views/devise/passwords/new.html.haml
@@ -4,9 +4,9 @@
   = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
     = render "devise/shared/error_messages", resource: resource
     .field
-      %h2.user__title Forgot your password?
+      %h2.user__title パスワードの再設定
       = f.label :メールアドレス
-      = f.email_field :email, autofocus: true, autocomplete: "email"
+      = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "メールアドレスを入力してください"
       %br/
     .field
       = f.submit "パスワードの再発行",class: "submit__btn"

--- a/app/views/devise/registrations/create_address.html.haml
+++ b/app/views/devise/registrations/create_address.html.haml
@@ -1,3 +1,6 @@
 .Wrapper
-  %h2.user__title 登録が完了しました
-  = link_to "トップへ戻る", root_path, class:"link__btn__center"
+  %br/
+  %br/
+  .field
+    %h2.user__title 登録が完了しました
+    = link_to "トップへ戻る", root_path, class:"link__btn__center"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -19,7 +19,7 @@
         = f.label :メールアドレス
         %span.necessarily 必須
         %br/
-        = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: " メールアドレスを入力してください"
+        = f.email_field :email, autofocus: true, autocomplete: "email", placeholder: " PC・携帯どちらでも可"
       - if @user.errors.include?(:email)
         %p.error_message メールアドレスを入力してください
       %br/
@@ -32,7 +32,6 @@
   
     .field
       .field__label
-        %br/
         = f.text_field :first_name, placeholder: " 例）太郎"
       - if @user.errors.include?(:family_name) || @user.errors.include?(:first_name)
         %p.error_message お名前を全角で入力してください
@@ -45,7 +44,6 @@
         = f.text_field :family_name_reading, placeholder: " 例）タナカ"
     .field
       .field__label
-        %br/
         = f.text_field :first_name_reading, placeholder: " 例）タロウ"
       - if @user.errors.include?(:family_name_reading) || @user.errors.include?(:first_name_reading)
         %p.error_message お名前を全角カタカナで入力してください

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -76,7 +76,7 @@
         = @user.errors.full_messages_for(:password_confirmation).first
       %br/
     .field
-      = f.submit "次へ進む", class: "submit__btn"
+      = f.submit "次へ進む", class: "submit__btn__user"
       = link_to "トップへ戻る", root_path, class:"link__btn__center"
-    %br/
+    %br
   -# = render "devise/shared/links"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -55,7 +55,7 @@
         = f.label :誕生日
         %span.necessarily 必須
         %br/
-        = f.text_field :birthday, placeholder: " 誕生日を入力してください"
+        != sprintf(f.date_select(:birthday, prefix:'birthday',with_css_classes:'birthday', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s'),'年','月')+'日'
       - if @user.errors.include?(:birthday)
         %p.error_message 誕生日を入力してください
       %br/

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -6,7 +6,7 @@
     .field
       %h2.user__title 発送元・お届け先住所情報登録
       .field__label
-        = f.label :郵便番号
+        = f.label :郵便番号（ハイフンなし７桁）
         %span.necessarily 必須
         %br/
         = f.text_field :post_code, autofocus: true, placeholder: " 例）1234567"
@@ -84,7 +84,7 @@
         = f.text_field :telephone_number,autofocus: true, placeholder: " 例）080-123-4567"
       %br/
     .field
-      = f.submit "登録する" , class: "submit__btn"
+      = f.submit "登録する" , class: "submit__btn__user"
       = link_to "トップへ戻る", root_path, class:"link__btn__center"
     %br/
   - render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -21,6 +21,7 @@
         = f.submit "ログイン", class: "submit__btn"
         = link_to "トップへ戻る", root_path, class: "link__btn__center"
         = link_to "パスワードを忘れた場合はこちら", new_password_path(resource_name),class: "link__btn__center"
+        %br/
     -# = render "devise/shared/links"
     %br/
 


### PR DESCRIPTION
# What
新規ユーザー登録及びログイン画面のビューを実装する
# Why
本アプリのサービスを使用する上でユーザーの情報という重要な情報を入力するものであるので入力する内容が
わかりやすいビューに整える。

### 新規登録画面
**ユーザー情報**

![localhost_3000_users_sign_up (2)](https://user-images.githubusercontent.com/66246442/94988556-28f9bf00-05a9-11eb-9ee4-ec559df12635.png)

**住所情報**
![localhost_3000_users](https://user-images.githubusercontent.com/66246442/94527083-6ee51900-0271-11eb-8022-764c58c8d410.png)
### ログイン画面
![localhost_3000_users_sign_in2](https://user-images.githubusercontent.com/66246442/94528806-ddc37180-0273-11eb-8266-03dc8e231ad3.png)
